### PR TITLE
Allocate larger struct work and gqw_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,9 +122,6 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Need _XOPEN_SRC
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_XOPEN_SRC")
 
-add_compile_definitions(-DDEBUG)
-set(CMAKE_C_FLAGS "-O0 -ggdb")
-
 # Define the DEBUG macro when building in debug mode
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG -Wall")
 

--- a/contrib/make_testindex.cpp
+++ b/contrib/make_testindex.cpp
@@ -470,7 +470,7 @@ void generatecurr(ThreadArgs *arg, const std::size_t files, std::list <off_t> &s
 
         const std::size_t bucket = bucket_rng(gen);
 
-        struct work *work = new_work_with_name("", s.str().c_str());
+        struct work *work = new_work_with_name(NULL, 0, s.str().c_str(), s.str().size());
         struct entry_data ed;
 
         ed.type = 'f';
@@ -548,7 +548,7 @@ void generatecurr(ThreadArgs *arg, const std::size_t files, std::list <off_t> &s
     }
 
     // summarize this directory
-    struct work *work = new_work_with_name("", arg->path.c_str());
+    struct work *work = new_work_with_name(NULL, 0, arg->path.c_str(), arg->path.size());
     struct entry_data ed;
 
     ed.type = 'd';

--- a/include/bf.h
+++ b/include/bf.h
@@ -297,6 +297,9 @@ struct work {
    refstr_t      root_parent;            /* dirname(realpath(argv[i])) */
    size_t        root_basename_len;      /* strlen(basename(argv[i])) */
    size_t        level;
+   char          *name;                  /* points to memory located after struct work */
+   size_t        name_len;               /* == strlen(name) - meaning excludes NUL! */
+   size_t        basename_len;           /* can usually get through readdir */
    long long int pinode;
    size_t        recursion_level;
 
@@ -304,13 +307,12 @@ struct work {
    char *        fullpath;
    size_t        fullpath_len;
 
-   size_t        name_len;               /* == strlen(name) - meaning excludes NUL! */
-   size_t        basename_len;           /* can usually get through readdir */
-   char          name[];
+   /* name is actually here, but not using flexible arrays */
 };
 
 size_t struct_work_size(struct work *w);
-struct work *new_work_with_name(const char *prefix, const char *name);
+struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
+                                const char *basename, const size_t basename_len);
 
 /* extra data used by entries that does not depend on data from other directories */
 struct entry_data {

--- a/include/compress.h
+++ b/include/compress.h
@@ -77,10 +77,9 @@ extern "C" {
  * another struct that needs compression
  */
 typedef struct compressed {
-    int8_t          yes;  /* is this struct compressed? */
+    int8_t          yes;      /* is this struct compressed? */
     uint16_t        orig_len; /* not a size_t to fit in hole in struct */
-    size_t          len;  /* includes self; only meaningful if yes == 1 */
-    char            data[0];
+    size_t          len;      /* includes self; only meaningful if yes == 1 */
 } compressed_t;
 
 #if HAVE_ZLIB /* or any other algorithm */
@@ -92,12 +91,6 @@ typedef struct compressed {
 void *compress_struct(const int comp, void *src, const size_t struct_len);
 
 void decompress_struct(void **dst, void *src);
-
-/*
- * used is the struct that was used for operations (decompressed or original data)
- * data is the original data received for processing, which may or may not have been used directly
- */
-void free_struct(void *used, void *data, const size_t recursion_level);
 
 #ifdef __cplusplus
 }

--- a/include/utils.h
+++ b/include/utils.h
@@ -167,6 +167,8 @@ void set_metadata(const char *path, struct stat *st, struct xattrs *xattrs);
 
 void dump_memory_usage(void);
 
+void decompress_work(struct work **dst, void *src);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,8 +195,9 @@ add_library(gufi_query_lib OBJECT
   gufi_query/PoolArgs.c
   gufi_query/aggregate.c
   gufi_query/external.c
-  gufi_query/processdir.c
+  gufi_query/gqw.c
   gufi_query/process_queries.c
+  gufi_query/processdir.c
   gufi_query/query.c
   gufi_query/timers.c
   gufi_query/validate_inputs.c

--- a/src/bfwreaddirplus2db.c
+++ b/src/bfwreaddirplus2db.c
@@ -219,7 +219,7 @@ static int reprocessdir(struct input *in, void *passv, DIR *dir) {
                 continue;
         }
 
-        struct work *qwork = new_work_with_name(passmywork->name,  entry->d_name);
+        struct work *qwork = new_work_with_name(passmywork->name, passmywork->name_len, entry->d_name, len);
         qwork->basename_len = len;
 
         struct entry_data qwork_ed;
@@ -389,7 +389,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
                 continue;
         }
 
-        struct work *qwork = new_work_with_name(passmywork->name, entry->d_name);
+        struct work *qwork = new_work_with_name(passmywork->name, passmywork->name_len, entry->d_name, len);
         struct entry_data qwork_ed;
         memset(&qwork_ed, 0, sizeof(qwork_ed));
 
@@ -610,7 +610,7 @@ static int processinit(struct PoolArgs *pa, QPTPool_t *ctx) {
         }
     }
 
-    struct work *mywork = new_work_with_name("", pa->in.name.data);
+    struct work *mywork = new_work_with_name(NULL, 0, pa->in.name.data, pa->in.name.len);
 
     QPTPool_enqueue(ctx, 0, processdir, mywork);
 

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -167,7 +167,6 @@ static int process_nondir(struct work *entry, struct entry_data *ed, void *args)
     }
 
 out:
-    free(entry);
     return rc;
 }
 
@@ -177,20 +176,19 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     int rc = 0;
 
     struct PoolArgs *pa = (struct PoolArgs *) args;
-    struct input *in = &pa->in;
 
     struct NonDirArgs nda;
     nda.in         = &pa->in;
     nda.temp_db    = &pa->db;
     nda.temp_xattr = &pa->xattr;
+    nda.work       = NULL;
     memset(&nda.ed, 0, sizeof(nda.ed));
     nda.topath     = NULL;
     nda.ed.type    = 'd';
 
     DIR *dir = NULL;
 
-    // TODO: check error
-    decompress_struct((void **) &nda.work, data);
+    decompress_work(&nda.work, data);
 
     if (lstat(nda.work->name, &nda.ed.statuso) != 0) {
         fprintf(stderr, "Could not stat directory \"%s\"\n", nda.work->name);
@@ -206,7 +204,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     }
 
     /* offset by work->root_len to remove prefix */
-    nda.topath_len = in->nameto.len + 1 + nda.work->name_len - nda.work->root_parent.len;
+    nda.topath_len = nda.in->nameto.len + 1 + nda.work->name_len - nda.work->root_parent.len;
 
     /*
      * allocate space for "/db.db" in nda.topath
@@ -217,7 +215,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     nda.topath = malloc(topath_size);
     SNFORMAT_S(nda.topath, topath_size, 4,
-               in->nameto.data, in->nameto.len,
+               nda.in->nameto.data, nda.in->nameto.len,
                "/", (size_t) 1,
                nda.work->name + nda.work->root_parent.len, nda.work->name_len - nda.work->root_parent.len,
                "\0" DBNAME, (size_t) 1 + DBNAME_LEN);
@@ -253,7 +251,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     nda.xattrs_res = NULL;
     nda.xattr_files_res = NULL;
 
-    if (in->process_xattrs) {
+    if (nda.in->process_xattrs) {
         nda.xattrs_res = insertdbprep(nda.db, XATTRS_PWD_INSERT);
         nda.xattr_files_res = insertdbprep(nda.db, EXTERNAL_DBS_PWD_INSERT);
 
@@ -263,14 +261,14 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     struct descend_counters ctrs;
     startdb(nda.db);
-    descend(ctx, id, pa, in, nda.work, nda.ed.statuso.st_ino, dir, 0,
+    descend(ctx, id, pa, nda.in, nda.work, nda.ed.statuso.st_ino, dir, 0,
             processdir, process_nondir, &nda,
             &ctrs);
     stopdb(nda.db);
 
     /* entries and xattrs have been inserted */
 
-    if (in->process_xattrs) {
+    if (nda.in->process_xattrs) {
         /* write out per-user and per-group xattrs */
         sll_destroy(&nda.xattr_db_list, destroy_xattr_db);
 
@@ -291,7 +289,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     /* the xattrs go into the xattrs_avail table in db.db */
     insertsumdb(nda.db, nda.work->name + nda.work->name_len - nda.work->basename_len,
                 nda.work, &nda.ed, &nda.summary);
-    if (in->process_xattrs) {
+    if (nda.in->process_xattrs) {
         xattrs_cleanup(&nda.ed.xattrs);
     }
 
@@ -361,7 +359,7 @@ static int validate_source(struct input *in, const char *path, struct work **wor
         return 1;
     }
 
-    struct work *new_work = new_work_with_name("", path);
+    struct work *new_work = new_work_with_name(NULL, 0, path, strlen(path));
 
     new_work->root_parent.data = path;
     new_work->root_parent.len = dirname_len(path, new_work->name_len);

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -132,16 +132,11 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     struct PoolArgs *pa = (struct PoolArgs *) args;
     struct input *in = &pa->in;
-    struct work *work = (struct work *) data;
+    struct work *work = NULL;
     struct entry_data ed;
     int rc = 0;
 
-    if (work->compressed.yes) {
-        struct work *work_src;
-        // TODO; check error
-        decompress_struct((void **) &work_src, work);
-        work = work_src;
-    }
+    decompress_work(&work, data);
 
     DIR *dir = opendir(work->name);
     if (!dir) {
@@ -185,7 +180,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
   cleanup:
     closedir(dir);
 
-    free_struct(work, data, work->recursion_level);
+    free(work);
 
     pa->total_files[id] += ctrs.nondirs_processed;
 
@@ -253,7 +248,7 @@ static int validate_source(const char *path, struct work **work) {
         return 1;
     }
 
-    struct work *new_work = new_work_with_name("", path);
+    struct work *new_work = new_work_with_name(NULL, 0, path, strlen(path));
 
     new_work->root_parent.data = path;
     new_work->root_parent.len = dirname_len(path, new_work->name_len);

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -436,7 +436,7 @@ struct work *validate_inputs(struct PoolArgs *pa) {
         return NULL;
     }
 
-    struct work *root = new_work_with_name("", pa->in.name.data);
+    struct work *root = new_work_with_name(NULL, 0, pa->in.name.data, pa->in.name.len);
     if (!root) {
         fprintf(stderr, "Could not allocate root struct\n");
         return NULL;

--- a/src/gufi_query/main.c
+++ b/src/gufi_query/main.c
@@ -193,7 +193,8 @@ int main(int argc, char *argv[])
         argvi_len = trailing_non_match_index(argv[i] + 1, argvi_len - 1, "/", 1) + 1;
 
         realpaths[i - idx] = realpath(argv[i], NULL);
-        if (!realpaths[i - idx]) {
+        char *root_name = realpaths[i - idx];
+        if (!root_name) {
             const int err = errno;
             fprintf(stderr, "Could not get realpath of \"%s\": %s (%d)\n",
                     argv[i], strerror(err), err);
@@ -201,7 +202,7 @@ int main(int argc, char *argv[])
         }
 
         struct stat st;
-        if (lstat(realpaths[i - idx], &st) != 0) {
+        if (lstat(root_name, &st) != 0) {
             const int err = errno;
             fprintf(stderr, "Could not stat directory \"%s\": %s (%d)\n",
                     argv[i], strerror(err), err);
@@ -214,25 +215,39 @@ int main(int argc, char *argv[])
             continue;
         }
 
-        gqw_t *root = calloc(1, sizeof(gqw_t));
-        root->work = new_work_with_name("", realpaths[i - idx]);
+        const size_t root_name_len = strlen(root_name);
+
+        /*
+         * get sqlite3 name (copied into root instead of written
+         * directly into root because root doesn't exist yet)
+         */
+        size_t rp_len = root_name_len;
+        char sqlite3_name[MAXPATH];
+        const size_t sqlite3_name_len = sqlite_uri_path(sqlite3_name, sizeof(sqlite3_name),
+                                                        root_name, &rp_len);
+
+        gqw_t *root = calloc(1, sizeof(*root) + root_name_len + 1 + sqlite3_name_len + 1);
+        root->work.name = (char *) &root[1];;
+        root->work.name_len = SNFORMAT_S(root->work.name, root_name_len + 1, 1,
+                                         root_name, root_name_len);
 
         /* keep original user input */
-        root->work->orig_root.data = argv[i];
-        root->work->orig_root.len = argvi_len;
+        root->work.orig_root.data = argv[i];
+        root->work.orig_root.len = argvi_len;
 
-         /* set initial work item directory to realpath(argv[i]) */
-        size_t rp_len = strlen(realpaths[i - idx]);
-        root->sqlite3_name_len = sqlite_uri_path(root->sqlite3_name, MAXPATH, realpaths[i - idx], &rp_len);
+        /* set modified path name for SQLite3 */
+        root->sqlite3_name = ((char *) root->work.name) + root->work.name_len + 1;
+        root->sqlite3_name_len = SNFORMAT_S(root->sqlite3_name, sqlite3_name_len + 1, 1,
+                                            sqlite3_name, sqlite3_name_len);
 
         /* parent of input path */
-        root->work->root_parent.data = realpaths[i - idx];
-        root->work->root_parent.len  = trailing_match_index(root->work->root_parent.data, root->work->name_len, "/", 1);
+        root->work.root_parent.data = realpaths[i - idx];
+        root->work.root_parent.len  = trailing_match_index(root->work.root_parent.data, root->work.name_len, "/", 1);
 
-        ((char *) root->work->root_parent.data)[root->work->root_parent.len] = '\0';
-        root->work->basename_len = root->work->name_len - root->work->root_parent.len;
+        ((char *) root->work.root_parent.data)[root->work.root_parent.len] = '\0';
+        root->work.basename_len = root->work.name_len - root->work.root_parent.len;
 
-        root->work->root_basename_len = root->work->basename_len;
+        root->work.root_basename_len = root->work.basename_len;
 
         /* push the path onto the queue (no compression) */
         QPTPool_enqueue(pool, i % in.maxthreads, processdir, root);

--- a/src/gufi_query/process_queries.c
+++ b/src/gufi_query/process_queries.c
@@ -95,7 +95,7 @@ static size_t descend2(QPTPool_t *ctx,
 
     descend_timestamp_start(dts, level_cmp);
     size_t pushed = 0;
-    const size_t next_level = gqw->work->level + 1;
+    const size_t next_level = gqw->work.level + 1;
     const int level_check = (next_level < max_level);
     descend_timestamp_end(level_cmp);
 
@@ -137,28 +137,11 @@ static size_t descend2(QPTPool_t *ctx,
                 descend_timestamp_end(strncmp_branch);
             }
 
-            gqw_t child;
-            memset(&child, 0, sizeof(child));
-
-            child.work = new_work_with_name(gqw->work->name, entry->d_name);
-
-            child.work->basename_len = len;
-            child.work->fullpath = NULL;
-            child.work->fullpath_len = 0;
-
-            descend_timestamp_start(dts, isdir_cmp);
             int isdir = (entry->d_type == DT_DIR);
-            if (!isdir) {
-                /* allow for paths immediately under the input paths to be symlinks */
-                if (next_level < 2) {
-                    struct stat st;
-                    if (stat(child.work->name, &st) == 0) {
-                        isdir = S_ISDIR(st.st_mode);
-                    }
-                    /* errors are ignored */
-                }
-            }
-            descend_timestamp_end(isdir_cmp);
+            gqw_t *child = new_gqw_with_name(gqw->work.name, gqw->work.name_len,
+                                             entry->d_name, len,
+                                             &isdir, next_level,
+                                             gqw->sqlite3_name, gqw->sqlite3_name_len);
 
             descend_timestamp_start(dts, isdir_branch);
             if (isdir) {
@@ -166,28 +149,19 @@ static size_t descend2(QPTPool_t *ctx,
 
                 descend_timestamp_start(dts, set);
 
-                child.work->level = next_level;
-                child.work->orig_root = gqw->work->orig_root;
-                child.work->root_parent = gqw->work->root_parent;
-                child.work->root_basename_len = gqw->work->root_basename_len;
+                child->work.basename_len = len;
+                child->work.fullpath = NULL;
+                child->work.fullpath_len = 0;
 
-                /* append converted entry name to converted directory */
-                child.sqlite3_name_len = SNFORMAT_S(child.sqlite3_name, MAXPATH, 2,
-                                                    gqw->sqlite3_name, gqw->sqlite3_name_len,
-                                                    "/", (size_t) 1);
-                const size_t converted_len = sqlite_uri_path(child.sqlite3_name + child.sqlite3_name_len,
-                                                            MAXPATH - child.sqlite3_name_len,
-                                                            entry->d_name, &len);
-                child.sqlite3_name_len += converted_len;
+                child->work.level = next_level;
+                child->work.orig_root = gqw->work.orig_root;
+                child->work.root_parent = gqw->work.root_parent;
+                child->work.root_basename_len = gqw->work.root_basename_len;
 
-                /* this is how the parent gets passed on */
                 descend_timestamp_end(set);
 
-                /* make a clone here so that the data can be pushed into the queue */
-                /* this is more efficient than malloc+free for every single entry */
                 descend_timestamp_start(dts, make_clone);
-                gqw_t *clone = calloc(sizeof(*clone), 1);
-                memcpy(clone, &child, sizeof(*clone));
+                gqw_t *clone = compress_struct(comp, child, gqw_size(child));
                 descend_timestamp_end(make_clone);
 
                 /* push the subdirectory into the queue for processing */
@@ -198,8 +172,7 @@ static size_t descend2(QPTPool_t *ctx,
                 pushed++;
             }
             else {
-                free(child.work)
-
+                free(child);
                 descend_timestamp_end(isdir_branch);
             }
         }
@@ -290,7 +263,7 @@ int process_queries(PoolArgs_t *pa,
                   /* if it fails then this will be set to 1 and will go on */
 
     /* only query this level if the min_level has been reached */
-    if (gqw->work->level >= in->min_level) {
+    if (gqw->work.level >= in->min_level) {
         if (sqlite3_create_function(db, "subdirs", 2, SQLITE_UTF8,
                                     subdirs_walked_count, &subdirs,
                                     NULL, NULL) != SQLITE_OK) {
@@ -304,13 +277,13 @@ int process_queries(PoolArgs_t *pa,
 
         /* run query on summary, print it if printing is needed, if returns none */
         /* and we are doing AND, skip querying the entries db */
-        shortpath(gqw->work->name, shortname, endname);
+        shortpath(gqw->work.name, shortname, endname);
 
         if (in->sql.sum.len) {
             recs=1; /* set this to one record - if the sql succeeds it will set to 0 or 1 */
             /* put in the path relative to the user's input */
             thread_timestamp_start(sqlsum, &ts->tts[tts_sqlsum]);
-            querydb(gqw->work, dbname, dbname_len, db, in->sql.sum.data, pa, id, print_parallel, &recs);
+            querydb(&gqw->work, dbname, dbname_len, db, in->sql.sum.data, pa, id, print_parallel, &recs);
             thread_timestamp_end(sqlsum);
             increment_query_count(ta);
         } else {
@@ -323,7 +296,7 @@ int process_queries(PoolArgs_t *pa,
         if (recs > 0) {
             if (in->sql.ent.len) {
                 thread_timestamp_start(sqlent, &ts->tts[tts_sqlent]);
-                querydb(gqw->work, dbname, dbname_len, db, in->sql.ent.data, pa, id, print_parallel, &recs); /* recs is not used */
+                querydb(&gqw->work, dbname, dbname_len, db, in->sql.ent.data, pa, id, print_parallel, &recs); /* recs is not used */
                 thread_timestamp_end(sqlent);
                 increment_query_count(ta);
             }

--- a/src/gufi_query/processdir.c
+++ b/src/gufi_query/processdir.c
@@ -90,7 +90,7 @@ static inline int save_matime(gqw_t *gqw,
                               char *dbpath, const size_t dbpath_size,
                               struct utimbuf *dbtime) {
     const size_t dbpath_len = SNFORMAT_S(dbpath, dbpath_size, 2,
-                                         gqw->work->name, gqw->work->name_len,
+                                         gqw->work.name, gqw->work.name_len,
                                          "/" DBNAME, DBNAME_LEN + 1);
     struct stat st;
     if (lstat(dbpath, &st) != 0) {
@@ -98,7 +98,7 @@ static inline int save_matime(gqw_t *gqw,
 
         char buf[MAXPATH];
         present_user_path(dbpath, dbpath_len,
-                          &gqw->work->root_parent, gqw->work->root_basename_len, &gqw->work->orig_root,
+                          &gqw->work.root_parent, gqw->work.root_basename_len, &gqw->work.orig_root,
                           buf, sizeof(buf));
 
         fprintf(stderr, "Could not stat database file \"%s\": %s (%d)\n",
@@ -161,10 +161,8 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     struct input *in = pa->in;
     ThreadArgs_t *ta = &(pa->ta[id]);
 
-    gqw_t stack = { 0 };
-    gqw_t *gqw = &stack;
-
-    decompress_struct((void **) &gqw, data);
+    gqw_t *gqw = NULL;
+    decompress_gqw(&gqw, data);
 
     char dbpath[MAXPATH];  /* filesystem path of db.db; only generated if keep_matime is set */
     char dbname[MAXPATH];  /* path of db.db modified so that sqlite3 can open it */
@@ -179,7 +177,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     /* keep opendir near opendb to help speed up sqlite3_open_v2 */
     thread_timestamp_start(opendir_call, &ts.tts[tts_opendir_call]);
-    dir = opendir(gqw->work->name);
+    dir = opendir(gqw->work.name);
     thread_timestamp_end(opendir_call);
 
     /* if the directory can't be opened, don't bother with anything else */
@@ -198,7 +196,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         goto close_dir;
     }
 
-    if (gqw->work->level >= in->min_level) {
+    if (gqw->work.level >= in->min_level) {
         #if OPENDB
         thread_timestamp_start(attachdb_call, &ts.tts[tts_attachdb_call]);
         db = attachdb(dbname, ta->outdb, ATTACH_NAME, in->open_flags, 1);
@@ -210,7 +208,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         #ifdef ADDQUERYFUNCS
         thread_timestamp_start(addqueryfuncs_call, &ts.tts[tts_addqueryfuncs_call]);
         if (db) {
-            if (addqueryfuncs_with_context(db, gqw->work) != 0) {
+            if (addqueryfuncs_with_context(db, &gqw->work) != 0) {
                 fprintf(stderr, "Could not add functions to sqlite\n");
             }
         }
@@ -221,7 +219,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     /* get number of subdirs walked on first call to process_queries */
     size_t subdirs_walked_count = 0;
 
-    if (db && (gqw->work->level >= in->min_level)) {
+    if (db && (gqw->work.level >= in->min_level)) {
         int recs = 1;
 
         /*
@@ -235,7 +233,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
             if (in->andor == AND) {
                 /* make sure the treesummary table exists */
                 thread_timestamp_start(sqltsumcheck, &ts.tts[tts_sqltsumcheck]);
-                querydb(gqw->work, dbname, dbname_len, db, "SELECT name FROM " ATTACH_NAME ".sqlite_master "
+                querydb(&gqw->work, dbname, dbname_len, db, "SELECT name FROM " ATTACH_NAME ".sqlite_master "
                         "WHERE (type == 'table') AND (name == '" TREESUMMARY "');",
                         pa, id, count_rows, &recs);
                 thread_timestamp_end(sqltsumcheck);
@@ -246,7 +244,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
                 else {
                     /* run in->sql.tsum */
                     thread_timestamp_start(sqltsum, &ts.tts[tts_sqltsum]);
-                    querydb(gqw->work, dbname, dbname_len, db, in->sql.tsum.data, pa, id, print_parallel, &recs);
+                    querydb(&gqw->work, dbname, dbname_len, db, in->sql.tsum.data, pa, id, print_parallel, &recs);
                     thread_timestamp_end(sqltsum);
                     increment_query_count(ta);
                 }
@@ -268,7 +266,7 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
              */
             if (in->process_xattrs) {
                 setup_xattrs_views(in, db,
-                                   gqw->work,
+                                   &gqw->work,
                                    &extdb_count
                                    #if defined(DEBUG) && (defined(CUMULATIVE_TIMES) || defined(PER_THREAD_STATS))
                                    , &ts.tts[tts_xattrprep_call]
@@ -441,9 +439,10 @@ int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     ;
 
     thread_timestamp_start(free_work, &ts.tts[tts_free_work]);
-    free(gqw->work->fullpath);
-    free(gqw->work);
-    free_struct(gqw, data, 0);
+
+    free(gqw->work.fullpath);
+    free(gqw);
+
     thread_timestamp_end(free_work);
 
     #if defined(DEBUG) && defined(PER_THREAD_STATS)

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -339,7 +339,7 @@ int main(int argc, char *argv[]) {
         zeroit(&pa.sums[i]);
     }
 
-    struct work *root = new_work_with_name("", pa.in.name.data);
+    struct work *root = new_work_with_name(NULL, 0, pa.in.name.data, pa.in.name.len);
     root->name_len = trailing_non_match_index(root->name, root->name_len, "/", 1);
 
     QPTPool_enqueue(pool, 0, processdir, root);

--- a/src/trace.c
+++ b/src/trace.c
@@ -133,7 +133,7 @@ int linetowork(char *line, const size_t len, const char delim,
     char *q;
 
     p=line; q = split(p, &delim, 1, end);
-    struct work *new_work = new_work_with_name("", p);
+    struct work *new_work = new_work_with_name(NULL, 0, p, q - p);
     *work = new_work;
 
     p = q;  q = split(p, &delim, 1, end); ed->type = *p;

--- a/src/utils.c
+++ b/src/utils.c
@@ -376,7 +376,7 @@ size_t SNFORMAT_S(char *dst, const size_t dst_len, size_t count, ...) {
  * Size of base struct plus size of stored name plus NUL terminator.
  */
 size_t struct_work_size(struct work *w) {
-    return sizeof(struct work) + w->name_len + 1;
+    return sizeof(*w) + w->name_len + 1;
 }
 
 /*
@@ -387,40 +387,21 @@ size_t struct_work_size(struct work *w) {
  *   - name
  *   - name_len
  */
-struct work *new_work_with_name(const char *prefix, const char *basename) {
-    struct work *w;
+struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
+                                const char *basename, const size_t basename_len) {
+    /* +1 for path separator */
+    const size_t name_total = prefix_len + 1 + basename_len;
 
-    size_t prefix_len;
-    if (*prefix == '\0') {
-        prefix_len = 0;
+    struct work *w = calloc(1, sizeof(*w) + name_total + 1);
+    w->name = (char *) &w[1];
+    if (prefix_len == 0) {
+        w->name_len = SNFORMAT_S(w->name, name_total + 1, 1,
+                                 basename, basename_len);
     } else {
-        /* Account for added '/' divider when there is a prefix. */
-        prefix_len = strnlen(prefix, MAXPATH) + 1;
-    }
-
-    size_t base_len = strnlen(basename, MAXPATH - prefix_len);
-
-    /* Extra plus 1 for terminating NUL. */
-    size_t name_total = prefix_len + base_len + 1;
-
-    w = calloc(1, sizeof *w + name_total);
-    if (w == NULL) {
-        /*
-         * If we can't allocate memory, we can't make any useful progress,
-         * so just bail.
-         */
-        fprintf(stderr, "Failed to allocate memory for struct work.\n");
-        exit(1);
-    }
-
-    if (*prefix == '\0') {
-        w->name_len = SNFORMAT_S(w->name, name_total, 1,
-                                 basename, base_len);
-    } else {
-        w->name_len = SNFORMAT_S(w->name, name_total, 3,
-                                 prefix, prefix_len - 1,
+        w->name_len = SNFORMAT_S(w->name, name_total + 1, 3,
+                                 prefix, prefix_len,
                                  "/", (size_t) 1,
-                                 basename, base_len);
+                                 basename, basename_len);
     }
 
     // TODO: should this initialize basename length?
@@ -479,7 +460,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
                 continue;
             }
 
-            struct work *child = new_work_with_name(work->name, dir_child->d_name);
+            struct work *child = new_work_with_name(work->name, work->name_len, dir_child->d_name, len);
 
             struct entry_data child_ed;
             memset(&child_ed, 0, sizeof(child_ed));
@@ -559,6 +540,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
             }
             else {
                 /* other types are not stored */
+                free(child);
                 continue;
             }
 
@@ -576,9 +558,9 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
                 if (in->process_xattrs) {
                     xattrs_cleanup(&child_ed.xattrs);
                 }
-            } else {
-                free(child);
             }
+
+            free(child);
         }
     }
 
@@ -996,4 +978,9 @@ void dump_memory_usage(void) {
     if (p)
         printf("%s\n", p);
     #endif
+}
+
+void decompress_work(struct work **dst, void *src) {
+    decompress_struct((void **) dst, src);
+    (*dst)->name = (char *) &(*dst)[1];
 }

--- a/test/unit/googletest/dbutils.cpp.in
+++ b/test/unit/googletest/dbutils.cpp.in
@@ -167,7 +167,7 @@ TEST(inserttreesumdb, nullptr) {
 TEST(addqueryfuncs, path) {
     const char dirname[MAXPATH] = "dirname";
 
-    struct work *work = new_work_with_name("index_root", dirname);
+    struct work *work = new_work_with_name("index_root", 10, dirname, strlen(dirname));
     work->orig_root.data = "index_root";
     work->orig_root.len = strlen(work->orig_root.data);
     work->root_parent.data = "";
@@ -193,7 +193,7 @@ TEST(addqueryfuncs, path) {
 TEST(addqueryfuncs, epath) {
     const char dirname[MAXPATH] = "dirname";
 
-    struct work *work = new_work_with_name("index_root", dirname);
+    struct work *work = new_work_with_name("index_root", 10, dirname, strlen(dirname));
     work->basename_len = strlen(dirname);
     work->root_parent.data = "index_root";     // currently at index_root/dirname
     work->root_parent.len = strlen(work->root_parent.data);
@@ -210,10 +210,11 @@ TEST(addqueryfuncs, epath) {
     EXPECT_STREQ(output, dirname);
 
     sqlite3_close(db);
+    free(work);
 }
 
 TEST(addqueryfuncs, fpath) {
-    struct work *work = new_work_with_name("", "");
+    struct work *work = new_work_with_name(NULL, 0, NULL, 0);
     work->name_len = SNPRINTF(work->name, MAXPATH, "/");
     work->fullpath = nullptr;
 
@@ -242,7 +243,7 @@ TEST(addqueryfuncs, fpath) {
 TEST(addqueryfuncs, rpath) {
     const char dirname[MAXPATH] = "dirname";
 
-    struct work *work = new_work_with_name("index_root", dirname);
+    struct work *work = new_work_with_name("index_root", 10, dirname, strlen(dirname));
     work->orig_root.data = "index_root";
     work->orig_root.len = strlen(work->orig_root.data);
     work->root_parent.data = "";
@@ -495,7 +496,7 @@ TEST(addqueryfuncs, human_readable_size) {
 }
 
 TEST(addqueryfuncs, level) {
-    struct work *work = new_work_with_name("", "");
+    struct work *work = new_work_with_name(NULL, 0, NULL, 0);
 
     sqlite3 *db = nullptr;
     ASSERT_EQ(sqlite3_open(SQLITE_MEMORY, &db), SQLITE_OK);
@@ -519,7 +520,7 @@ TEST(addqueryfuncs, level) {
 }
 
 TEST(addqueryfuncs, starting_point) {
-    struct work *work = new_work_with_name("", "");
+    struct work *work = new_work_with_name(NULL, 0, NULL, 0);
     work->orig_root.data = "/index_root";
     work->orig_root.len = strlen(work->orig_root.data);
 

--- a/test/unit/googletest/external.cpp.in
+++ b/test/unit/googletest/external.cpp.in
@@ -158,7 +158,7 @@ TEST(external, read_file) {
 
     struct input in;
 
-    struct work *work = new_work_with_name("", filename);
+    struct work *work = new_work_with_name(NULL, 0, filename, strlen(filename));
     work->basename_len = work->name_len;
 
     // skip checking path is valid db

--- a/test/unit/googletest/trace.cpp
+++ b/test/unit/googletest/trace.cpp
@@ -98,7 +98,7 @@ static const char EXPECTED_XATTRS_STR[] = "xattr.key0\x1fxattr.val0\x1f"
 static const size_t EXPECTED_XATTRS_STR_LEN = sizeof(EXPECTED_XATTRS_STR) - 1;
 
 static struct work *get_work(struct entry_data *ed) {
-    struct work *new_work = new_work_with_name("", "name");
+    struct work *new_work  = new_work_with_name(NULL, 0, "name", 4);
     ed->type               = 't';
     snprintf(ed->linkname, sizeof(ed->linkname), "link");
     ed->statuso.st_ino     = 0xfedc;
@@ -223,7 +223,7 @@ TEST(trace, worktofile) {
 }
 
 #define COMPARE(src, src_ed, dst, dst_ed)                               \
-    EXPECT_STREQ(dst->name,               src->name);                     \
+    EXPECT_STREQ(dst->name,              src->name);                    \
     EXPECT_EQ(dst_ed.type,               src_ed.type);                  \
     EXPECT_EQ(dst_ed.statuso.st_ino,     src_ed.statuso.st_ino);        \
     EXPECT_EQ(dst_ed.statuso.st_mode,    src_ed.statuso.st_mode);       \
@@ -244,7 +244,7 @@ TEST(trace, worktofile) {
     EXPECT_EQ(dst_ed.ossint4,            src_ed.ossint4);               \
     EXPECT_STREQ(dst_ed.osstext1,        src_ed.osstext1);              \
     EXPECT_STREQ(dst_ed.osstext2,        src_ed.osstext2);              \
-    EXPECT_EQ(dst->pinode,                src->pinode);                   \
+    EXPECT_EQ(dst->pinode,               src->pinode);                  \
 
 TEST(trace, linetowork) {
     struct entry_data src_ed;
@@ -270,6 +270,7 @@ TEST(trace, linetowork) {
 
     xattrs_cleanup(&ed.xattrs);
     free(work);
+    free(src);
 
     EXPECT_EQ(linetowork(nullptr, rc, delim, &work, &ed),  -1);
     EXPECT_EQ(linetowork(line, rc, delim, nullptr,  &ed),  -1);
@@ -288,6 +289,7 @@ TEST(scout_trace, no_cleanup) {
     // write the known struct to a string using an alternative write function
     char line[4096];
     const int rc = to_string(line, sizeof(line), src, &src_ed);
+    free(src);
     ASSERT_GT(rc, -1);
     const size_t len = strlen(line);
     ASSERT_EQ(rc, (int) len);

--- a/test/unit/googletest/utils.cpp.in
+++ b/test/unit/googletest/utils.cpp.in
@@ -156,7 +156,7 @@ TEST(summary, sumit_file) {
     struct sum summary;
     ASSERT_EQ(zeroit(&summary), 0);
 
-    struct work *pwork = new_work_with_name("", "");
+    struct work *pwork = new_work_with_name(NULL, 0, NULL, 0);
     struct entry_data ed;
     memset(&ed, 0, sizeof(ed));
 
@@ -216,7 +216,7 @@ TEST(summary, sumit_link) {
     struct sum summary;
     ASSERT_EQ(zeroit(&summary), 0);
 
-    struct work *pwork = new_work_with_name("", "");
+    struct work *pwork = new_work_with_name(NULL, 0, NULL, 0);
     struct entry_data ed;
     memset(&ed, 0, sizeof(ed));
 
@@ -649,8 +649,8 @@ TEST(descend, builddir) {
     const char pipename[] = "@CMAKE_BINARY_DIR@/testpipe";
     ASSERT_EQ(mkfifo(pipename, S_IRUSR | S_IWUSR), 0);
 
-    // TODO: does this need free() here?
-    struct work *work = new_work_with_name("", "@CMAKE_BINARY_DIR@");
+    const char root[] = "@CMAKE_BINARY_DIR@";
+    struct work *work = new_work_with_name(NULL, 0, root, strlen(root));
 
     DIR *dir = opendir(work->name);
     ASSERT_NE(dir, nullptr);
@@ -721,10 +721,7 @@ TEST(descend, builddir) {
         in.subdir_limit = 1;
         EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
-                              struct work *work = (struct work *) data;
-                              if (work->recursion_level == 0) {
-                                  free(data);
-                              }
+                              free(data);
                               return 0;
                           },
                           nullptr, nullptr,
@@ -740,6 +737,7 @@ TEST(descend, builddir) {
     QPTPool_destroy(pool);
 
     EXPECT_EQ(closedir(dir),    0);
+    free(work);
     EXPECT_EQ(unlink(pipename), 0);
     EXPECT_EQ(unlink(linkname), 0);
 }


### PR DESCRIPTION
This is not quite the same as flexible arrays - the named member is not located at the start of the data. Instead, the named member points to an address after the struct:
- `struct work` `name` now points to the area immediately after `struct work`
  - in `gqw_t`, it points to the area immediately after `sqlite3_name_len`
- `gqw_t` `sqlite3_name` points to the area immediately after `struct work` `name`

Added `decompress_work` to set name address after `decompress_struct`
Added `decompress_gqw` to set `struct work` `name` and `sqlite3_name` addresses after `decompress_struct` 
Changed `new_work_with_name` to not recalulcate string lengths 
Added `new_gqw_work_with_name`